### PR TITLE
feat: Support to load response headers from manifest file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -467,10 +467,17 @@ function buildSingleConfig (configName, singleUserConfig, commonConfig, includeI
 
   // absolute paths
   const actions = pathConfigValueToAbs(singleUserConfig.actions, fullKeyPrefix + '.actions', includeIndex) || defaultActionPath
-  const web = pathConfigValueToAbs(singleUserConfig.web, fullKeyPrefix + '.web', includeIndex) || defaultWebPath
   const unitTest = pathConfigValueToAbs(singleUserConfig.unitTest, fullKeyPrefix + '.web', includeIndex) || defaultUnitTestPath
   const e2eTest = pathConfigValueToAbs(singleUserConfig.e2eTest, fullKeyPrefix + '.web', includeIndex) || defaultE2eTestPath
   const dist = pathConfigValueToAbs(singleUserConfig.dist, fullKeyPrefix + '.dist', includeIndex) || defaultDistPath
+
+  let web
+  if (!singleUserConfig.web || typeof singleUserConfig.web === 'string') {
+    // keep backward compatibility - web src is directly defined as string web: web-src
+    web = pathConfigValueToAbs(singleUserConfig.web, fullKeyPrefix + '.web', includeIndex) || defaultWebPath
+  } else {
+    web = pathConfigValueToAbs(singleUserConfig.web.src, fullKeyPrefix + '.web', includeIndex) || defaultWebPath
+  }
 
   config.tests.unit = path.resolve(unitTest)
   config.tests.e2e = path.resolve(e2eTest)
@@ -497,6 +504,9 @@ function buildSingleConfig (configName, singleUserConfig, commonConfig, includeI
 
   // web
   config.web.src = path.resolve(web) // needed for app add first web-assets
+  if (singleUserConfig.web && singleUserConfig.web['response-headers']) {
+    config.web['response-headers'] = singleUserConfig.web['response-headers']
+  }
   if (config.app.hasFrontend) {
     config.web.injectedConfig = path.resolve(path.join(web, 'src', 'config.json'))
     // only add subfolder name if dist is default value

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -329,4 +329,77 @@ application:
     config = loadConfig({})
     expect(config.all.application.manifest.full).toEqual({ iam: 'empty' })
   })
+
+  test('manifest with response headers and web src', async () => {
+    global.fakeFileSystem.addJson(
+      {
+        '/package.json': '{}',
+        '/app.config.yaml': `
+        application:
+          web:
+            src: 'web-src'
+            response-headers:
+              /*:
+                testHeader: foo
+          runtimeManifest:
+            iam: empty
+`
+      }
+    )
+    config = loadConfig({})
+    expect(config.all.application.web['response-headers']).toEqual({ '/*': { testHeader: 'foo' } })
+  })
+
+  test('manifest with multiple response headers', async () => {
+    global.fakeFileSystem.addJson(
+      {
+        '/package.json': '{}',
+        '/app.config.yaml': `
+        application:
+          web:
+            src: 'web-src'
+            response-headers:
+              /*:
+                testHeader1: foo1
+                testHeader2: foo2
+                testHeader3: foo3
+              /*.html:
+                testHeader: htmlFoo
+              /*.js:
+                testHeader: jsFoo
+              /test/folder/*:
+                testHeader: folderFoo
+          runtimeManifest:
+            iam: empty
+`
+      }
+    )
+    const expectedRes = {
+      '/*': { testHeader1: 'foo1', testHeader2: 'foo2', testHeader3: 'foo3' },
+      '/*.html': { testHeader: 'htmlFoo' },
+      '/*.js': { testHeader: 'jsFoo' },
+      '/test/folder/*': { testHeader: 'folderFoo' }
+    }
+    config = loadConfig({})
+    expect(config.all.application.web['response-headers']).toEqual(expectedRes)
+  })
+
+  test('manifest with response headers and default web src', async () => {
+    global.fakeFileSystem.addJson(
+      {
+        '/package.json': '{}',
+        '/app.config.yaml': `
+        application:
+          web:
+            response-headers:
+              /*:
+                testHeader: foo
+          runtimeManifest:
+            iam: empty
+`
+      }
+    )
+    config = loadConfig({})
+    expect(config.all.application.web['response-headers']).toEqual({ '/*': { testHeader: 'foo' } })
+  })
 })


### PR DESCRIPTION
Support for users to specify response headers via app manifest.
Response Headers are defined under application -> web -> response-headers
Changes keep config loading backward compatible. 
Proposed manifest structure
```application:
          web:
            src: 'web-src'
            response-headers:
              /*:
                testHeader1: foo1
                testHeader2: foo2
                testHeader3: foo3
              /*.html:
                testHeader: htmlFoo
              /*.js:
                testHeader: jsFoo
              /test/folder/*:
                testHeader: folderFoo
          runtimeManifest: ...```

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

To provide a way for users to specify response headers on static assets served from CDN

## How Has This Been Tested?

unit tests, manual e2e

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
