### PR TITLE
Fix: strict type object validation

### DIFF
--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -22,6 +22,7 @@
       "patternProperties": {
         "^[A-Za-z0-9-_/\\-]+$": {
           "$ref": "#/definitions/application",
+          "type": "object",
           "properties": {
             "operations": {
               "type": "object",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When validating using ajv we get the following console logs:

```
strict mode: missing type "object" for keyword "required" at "https://adobe.io/schemas/app-builder/app.config.yaml.json/v2#/patternProperties/%5E%5BA-Za-z0-9-_~1%5C-%5D%2B%24" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "https://adobe.io/schemas/app-builder/app.config.yaml.json/v2#/patternProperties/%5E%5BA-Za-z0-9-_~1%5C-%5D%2B%24" (strictTypes)
```

this is a fix for it
