### PR TITLE
fix: support object as action.input type

### DIFF
--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -140,7 +140,7 @@
       "type": "object",
       "patternProperties": {
         "^[^\n]+$": {
-          "type": ["string", "boolean"]
+          "type": ["string", "boolean", "object"]
         }
       },
       "additionalProperties": false

--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -140,7 +140,7 @@
       "type": "object",
       "patternProperties": {
         "^[^\n]+$": {
-          "type": ["string", "boolean", "object"]
+          "type": ["string", "boolean"]
         }
       },
       "additionalProperties": false

--- a/test/__fixtures__/app-exc-nui/app.config.yaml
+++ b/test/__fixtures__/app-exc-nui/app.config.yaml
@@ -13,6 +13,10 @@ application:
             runtime: 'nodejs:14'
             inputs:
               LOG_LEVEL: 'debug'
+              SOMETHING:
+                type: string
+                description: this is about something
+                default: ''
             annotations:
               'require-adobe-auth': true
               final: true

--- a/test/__fixtures__/app/app.config.yaml
+++ b/test/__fixtures__/app/app.config.yaml
@@ -13,6 +13,10 @@ application:
             runtime: 'nodejs:14'
             inputs:
               LOG_LEVEL: 'debug'
+              SOMETHING:
+                type: string
+                description: this is about something
+                default: ''
             annotations:
               'require-adobe-auth': true
               final: true

--- a/test/__fixtures__/legacy-app/manifest.yml
+++ b/test/__fixtures__/legacy-app/manifest.yml
@@ -8,6 +8,10 @@ packages:
         runtime: 'nodejs:14'
         inputs:
           LOG_LEVEL: 'debug'
+          SOMETHING:
+            type: string
+            description: this is about something
+            default: ''
         annotations:
           'require-adobe-auth': true
           final: true

--- a/test/data-mocks/config-loader-include-index.js
+++ b/test/data-mocks/config-loader-include-index.js
@@ -179,6 +179,22 @@ const appIncludeIndex = {
     file: 'app.config.yaml',
     key: 'application.runtimeManifest.packages.my-app-package.actions.action.inputs.LOG_LEVEL'
   },
+  'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING': {
+    file: 'app.config.yaml',
+    key: 'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING'
+  },
+  'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.default': {
+    file: 'app.config.yaml',
+    key: 'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.default'
+  },
+  'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.description': {
+    file: 'app.config.yaml',
+    key: 'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.description'
+  },
+  'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.type': {
+    file: 'app.config.yaml',
+    key: 'application.runtimeManifest.packages.my-app-package.actions.action.inputs.SOMETHING.type'
+  },
   'application.runtimeManifest.packages.my-app-package.actions.action.runtime': {
     file: 'app.config.yaml',
     key: 'application.runtimeManifest.packages.my-app-package.actions.action.runtime'
@@ -621,6 +637,22 @@ const legacyIncludeIndex = {
   'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.inputs.LOG_LEVEL': {
     file: 'manifest.yml',
     key: 'packages.__APP_PACKAGE__.actions.action.inputs.LOG_LEVEL'
+  },
+  'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING': {
+    file: 'manifest.yml',
+    key: 'packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING'
+  },
+  'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.default': {
+    file: 'manifest.yml',
+    key: 'packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.default'
+  },
+  'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.description': {
+    file: 'manifest.yml',
+    key: 'packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.description'
+  },
+  'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.type': {
+    file: 'manifest.yml',
+    key: 'packages.__APP_PACKAGE__.actions.action.inputs.SOMETHING.type'
   },
   'application.runtimeManifest.packages.__APP_PACKAGE__.actions.action.runtime': {
     file: 'manifest.yml',

--- a/test/data-mocks/config-loader.js
+++ b/test/data-mocks/config-loader.js
@@ -45,7 +45,12 @@ function fullFakeRuntimeManifest (pathToActionFolder, pkgName1) {
             web: 'yes',
             runtime: 'nodejs:14',
             inputs: {
-              LOG_LEVEL: 'debug'
+              LOG_LEVEL: 'debug',
+              SOMETHING: {
+                type: 'string',
+                description: 'this is about something',
+                default: ''
+              }
             },
             annotations: {
               'require-adobe-auth': true,


### PR DESCRIPTION
action.input validation fails if the input type is not `string` or `boolean`.

See [example config](https://github.com/adobe/appbuilder-quickstarts/blob/63cd493e5949d8e5899c76cbc6c8f2c159e45160/action-sequences/src/dx-excshell-1/ext.config.yaml#L37-L49)

Note that action.input's object [can also contain other types](https://github.com/apache/openwhisk-wskdeploy/blob/master/specification/html/spec_parameters.md), which is not covered here.

## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
