### PR TITLE
fix: ACNA-3397 - exclude `web-export` and `raw-http` properties in action, allow `web` property to be boolean

### DIFF
--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -129,7 +129,12 @@
       "type": "object",
       "properties": {
         "function": { "type": "string" },
-        "web": { "type": "string" },
+        "web": { 
+          "anyOf" : [
+            {"type": "string" },
+            {"type": "boolean" }
+          ]
+        },
         "runtime": { "type": "string" },
         "inputs": { "$ref": "#/definitions/inputs" },
         "annotations": { "$ref": "#/definitions/annotations" },

--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -133,8 +133,8 @@
         "runtime": { "type": "string" },
         "inputs": { "$ref": "#/definitions/inputs" },
         "annotations": { "$ref": "#/definitions/annotations" },
-        "web-export": false,
-        "raw-http": false
+        "web-export": { "not": {} },
+        "raw-http": { "not": {} }
       },
       "required": []
     },

--- a/schema/app.config.yaml.schema.json
+++ b/schema/app.config.yaml.schema.json
@@ -132,7 +132,9 @@
         "web": { "type": "string" },
         "runtime": { "type": "string" },
         "inputs": { "$ref": "#/definitions/inputs" },
-        "annotations": { "$ref": "#/definitions/annotations" }
+        "annotations": { "$ref": "#/definitions/annotations" },
+        "web-export": false,
+        "raw-http": false
       },
       "required": []
     },

--- a/test/__fixtures__/app-exc-nui/app.config.yaml
+++ b/test/__fixtures__/app-exc-nui/app.config.yaml
@@ -26,12 +26,12 @@ application:
               concurrency: 189
           'action-zip':
             function: 'myactions/action-zip'
-            web: 'yes'
+            web: 'true'
             runtime: 'nodejs:14'
         sequences:
           'action-sequence':
             actions: 'action, action-zip'
-            web: 'yes'
+            web: true
         triggers:
           trigger1: null
         rules:

--- a/test/__fixtures__/app/app.config.yaml
+++ b/test/__fixtures__/app/app.config.yaml
@@ -26,12 +26,12 @@ application:
               concurrency: 189
           'action-zip':
             function: 'myactions/action-zip'
-            web: 'yes'
+            web: 'true'
             runtime: 'nodejs:14'
         sequences:
           'action-sequence':
             actions: 'action, action-zip'
-            web: 'yes'
+            web: true
         triggers:
           trigger1: null
         rules:

--- a/test/__fixtures__/legacy-app/manifest.yml
+++ b/test/__fixtures__/legacy-app/manifest.yml
@@ -21,12 +21,12 @@ packages:
           concurrency: 189
       'action-zip':
         function: 'myactions/action-zip'
-        web: 'yes'
+        web: 'true'
         runtime: 'nodejs:14'
     sequences:
       'action-sequence':
         actions: 'action, action-zip'
-        web: 'yes'
+        web: true
     triggers:
       trigger1: null
     rules:

--- a/test/data-mocks/config-loader.js
+++ b/test/data-mocks/config-loader.js
@@ -65,14 +65,14 @@ function fullFakeRuntimeManifest (pathToActionFolder, pkgName1) {
           },
           'action-zip': {
             function: winCompat(`${pathToActionFolder}/action-zip`),
-            web: 'yes',
+            web: 'true',
             runtime: 'nodejs:14'
           }
         },
         sequences: {
           'action-sequence': {
             actions: 'action, action-zip',
-            web: 'yes'
+            web: true
           }
         },
         triggers: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -287,6 +287,44 @@ extensions:
     expect(config.implements).toEqual(['application'])
   })
 
+  test('action config with web-export not in annotations', async () => {
+    global.fakeFileSystem.addJson({
+      '/package.json': '{}',
+      '/app.config.yaml':
+`
+application:
+  runtimeManifest:
+    packages:
+      myapp:
+        actions:
+          generic:
+            function: actions/generic/index.js
+            runtime: nodejs:18
+            web-export: raw
+`
+    })
+    await expect(appConfig.load({})).rejects.toThrow('Missing or invalid keys in app.config.yaml:')
+  })
+
+  test('action config with raw-http not in annotations', async () => {
+    global.fakeFileSystem.addJson({
+      '/package.json': '{}',
+      '/app.config.yaml':
+`
+application:
+  runtimeManifest:
+    packages:
+      myapp:
+        actions:
+          generic:
+            function: actions/generic/index.js
+            runtime: nodejs:18
+            raw-http: true
+`
+    })
+    await expect(appConfig.load({})).rejects.toThrow('Missing or invalid keys in app.config.yaml:')
+  })
+
   // options
   test('standalone app config - ignoreAioConfig=true', async () => {
     global.loadFixtureApp('app')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,7 +62,51 @@ describe('load config', () => {
   test('exc with events config', async () => {
     global.loadFixtureApp('exc-with-events')
     config = await appConfig.load({})
-    expect(config.all['dx/excshell/1']).toEqual(expect.objectContaining({ events: { registrations: { 'Demo name': { description: 'Demo description', events_of_interest: [{ event_codes: ['com.adobe.platform.gdpr.joberror', 'com.adobe.platform.gdpr.producterror'], provider_metadata: 'gdpr_events' }, { event_codes: ['test-code-skrishna', 'card_abandonment'], provider_metadata: 'aem' }], runtime_action: 'my-exc-package/action' }, 'Event Registration Default': { description: 'Registration for IO Events', events_of_interest: [{ event_codes: ['com.adobe.platform.gdpr.joberror', 'com.adobe.platform.gdpr.producterror'], provider_metadata: 'gdpr_events' }], runtime_action: 'my-exc-package/action' } } } }))
+    const eventObj = {
+      events:
+        {
+          registrations:
+            {
+              'Demo name':
+                {
+                  description: 'Demo description',
+                  events_of_interest:
+                    [
+                      {
+                        event_codes:
+                          [
+                            'com.adobe.platform.gdpr.joberror',
+                            'com.adobe.platform.gdpr.producterror'
+                          ],
+                        provider_metadata: 'gdpr_events'
+                      },
+                      {
+                        event_codes: ['test-code-skrishna', 'card_abandonment'],
+                        provider_metadata: 'aem'
+                      }
+                    ],
+                  runtime_action: 'my-exc-package/action'
+                },
+              'Event Registration Default':
+                {
+                  description: 'Registration for IO Events',
+                  events_of_interest:
+                    [
+                      {
+                        event_codes:
+                          [
+                            'com.adobe.platform.gdpr.joberror',
+                            'com.adobe.platform.gdpr.producterror'
+                          ],
+                        provider_metadata: 'gdpr_events'
+                      }
+                    ],
+                  runtime_action: 'my-exc-package/action'
+                }
+            }
+        }
+    }
+    expect(config.all['dx/excshell/1']).toEqual(expect.objectContaining(eventObj))
   })
 
   test('standalone app, exc and nui extension config', async () => {


### PR DESCRIPTION
1. Exclude `web-export` and `raw-http` properties from action config (only should be in action annotations)
2. Add `web` property in `action` to also be `boolean` type (was just `string`)

- related: https://github.com/adobe/aio-cli-plugin-app/issues/823
- [reference](https://stackoverflow.com/questions/30515253/json-schema-valid-if-object-does-not-contain-a-particular-property#comment108327660_30725034)
- spec: https://github.com/apache/openwhisk-wskdeploy/blob/master/specification/html/spec_actions.md
- error in spec: https://github.com/apache/openwhisk-wskdeploy/pull/1162

## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
